### PR TITLE
Use artwork data to prepopulate artwork detail view

### DIFF
--- a/BitsoArtGallery.xcodeproj/project.pbxproj
+++ b/BitsoArtGallery.xcodeproj/project.pbxproj
@@ -75,6 +75,9 @@
 		2CED815C2B7EA316002B5FE4 /* FileManager+Bitso.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0F46482B7D1DA70047732E /* FileManager+Bitso.swift */; };
 		2CED815D2B7EA31A002B5FE4 /* DispatchQueue+Bitso.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED814C2B7E96D7002B5FE4 /* DispatchQueue+Bitso.swift */; };
 		2CED815E2B7EA324002B5FE4 /* APIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0DBF142B76BDBE00562658 /* APIs.swift */; };
+		2CED81602B7FA444002B5FE4 /* SkeletonRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED815F2B7FA444002B5FE4 /* SkeletonRectangle.swift */; };
+		2CED81612B7FA7D2002B5FE4 /* SkeletonRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED815F2B7FA444002B5FE4 /* SkeletonRectangle.swift */; };
+		2CED81622B7FA7D3002B5FE4 /* SkeletonRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED815F2B7FA444002B5FE4 /* SkeletonRectangle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -134,6 +137,7 @@
 		2CED814C2B7E96D7002B5FE4 /* DispatchQueue+Bitso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Bitso.swift"; sourceTree = "<group>"; };
 		2CED814E2B7E9845002B5FE4 /* MockDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDispatchQueue.swift; sourceTree = "<group>"; };
 		2CED81522B7E9D90002B5FE4 /* MockArtworkLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockArtworkLoader.swift; sourceTree = "<group>"; };
+		2CED815F2B7FA444002B5FE4 /* SkeletonRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonRectangle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -182,6 +186,7 @@
 			children = (
 				2C0DBF172B76C27B00562658 /* AsyncCachableImage.swift */,
 				2C9926152B7D43A30066CE80 /* ErrorSnackbar.swift */,
+				2CED815F2B7FA444002B5FE4 /* SkeletonRectangle.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -510,6 +515,7 @@
 				2C327D4E2B755CFE00F1F2B0 /* ArtworkCard.swift in Sources */,
 				2C327D1E2B752D5700F1F2B0 /* BitsoArtGalleryApp.swift in Sources */,
 				2C99261F2B7D8CBD0066CE80 /* ErrorHandlingViewModel.swift in Sources */,
+				2CED81602B7FA444002B5FE4 /* SkeletonRectangle.swift in Sources */,
 				2C0DBF182B76C27B00562658 /* AsyncCachableImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -528,6 +534,7 @@
 				2CED814B2B7E7E91002B5FE4 /* MockFileManager.swift in Sources */,
 				2C9926192B7D4B350066CE80 /* ArtworkServiceTests.swift in Sources */,
 				2CED812E2B7E6BE1002B5FE4 /* ViewModelFactory.swift in Sources */,
+				2CED81612B7FA7D2002B5FE4 /* SkeletonRectangle.swift in Sources */,
 				2CED81382B7E6C01002B5FE4 /* ArtworkCard.swift in Sources */,
 				2CED81342B7E6BF6002B5FE4 /* NetworkService.swift in Sources */,
 				2CED814F2B7E9845002B5FE4 /* MockDispatchQueue.swift in Sources */,
@@ -564,6 +571,7 @@
 				2CED81592B7EA2F6002B5FE4 /* NetworkService.swift in Sources */,
 				2CED815E2B7EA324002B5FE4 /* APIs.swift in Sources */,
 				2CED81562B7EA2DE002B5FE4 /* ArtworkService.swift in Sources */,
+				2CED81622B7FA7D3002B5FE4 /* SkeletonRectangle.swift in Sources */,
 				2CED81542B7EA108002B5FE4 /* MockArtworkLoader.swift in Sources */,
 				2C327D392B752D5900F1F2B0 /* BitsoArtGalleryUITests.swift in Sources */,
 				2CED815B2B7EA30A002B5FE4 /* NetworkError.swift in Sources */,

--- a/BitsoArtGallery/Models/ArtworkDetail.swift
+++ b/BitsoArtGallery/Models/ArtworkDetail.swift
@@ -13,7 +13,7 @@ struct ArtworkDetailResponse: Codable {
 struct ArtworkDetail: Codable {
     let id: Int
     let title: String
-    let artistDisplay: String
+    let artistDisplay: String?
     let dateDisplay: String
     let mediumDisplay: String
     let dimensions: String

--- a/BitsoArtGallery/ViewModels/ViewModelFactory.swift
+++ b/BitsoArtGallery/ViewModels/ViewModelFactory.swift
@@ -23,7 +23,7 @@ class ViewModelFactory: ObservableObject {
     }
     
     @MainActor
-    func makeArtworkDetailViewModel(for id: Int) -> ArtworkDetailViewModel {
-        return ArtworkDetailViewModel(artworkLoader: artworkLoader, artworkId: id)
+    func makeArtworkDetailViewModel(for artwork: Artwork) -> ArtworkDetailViewModel {
+        return ArtworkDetailViewModel(artworkLoader: artworkLoader, artwork: artwork)
     }
 }

--- a/BitsoArtGallery/Views/ArtworkList/ArtworkListView.swift
+++ b/BitsoArtGallery/Views/ArtworkList/ArtworkListView.swift
@@ -17,7 +17,7 @@ struct ArtworkListView: View {
                 List() {
                     ForEach(viewModel.artworks.enumerated().map({$0}), id: \.element.id) { index, artwork in
                         NavigationLink {
-                            ArtworkDetailView(viewModel: viewModelFactory.makeArtworkDetailViewModel(for: artwork.id))
+                            ArtworkDetailView(viewModel: viewModelFactory.makeArtworkDetailViewModel(for: artwork))
                         } label: {
                             ArtworkCard(artwork: artwork)
                                 .onAppear {

--- a/BitsoArtGallery/Views/Shared/SkeletonRectangle.swift
+++ b/BitsoArtGallery/Views/Shared/SkeletonRectangle.swift
@@ -1,0 +1,30 @@
+//
+//  SkeletonRectangle.swift
+//  BitsoArtGallery
+//
+//  Created by Iñaki Yabar Bilbao on 16/02/2024.
+//
+
+import SwiftUI
+
+struct SkeletonRectangle: View {
+    @State private var isBlinking = false
+    
+    var body: some View {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(Color.gray.opacity(0.5))
+            .frame(width: 100, height: 20)
+            .opacity(isBlinking ? 0.3 : 1)
+            .animation(.easeInOut(duration: 0.8).repeatForever(), value: isBlinking)
+            .onAppear {
+                isBlinking.toggle()
+            }
+    }
+}
+
+struct SkeletonRectangle_Previews: PreviewProvider {
+    static var previews: some View {
+        SkeletonRectangle()
+    }
+}
+

--- a/BitsoArtGalleryTests/Mocks/MockArtworks.swift
+++ b/BitsoArtGalleryTests/Mocks/MockArtworks.swift
@@ -8,7 +8,7 @@
 import Foundation
 class MockArtworks {
     static let artworkWithImage = Artwork(id: 123, title: "Some art", artistTitle: "John Doe", departmentTitle: "Contemporary", imageId: "123-456")
-    static let artworkWithoutImage = Artwork(id: 123, title: "Some art", artistTitle: "John Doe", departmentTitle: "Contemporary", imageId: nil)
+    static let artworkWithoutImage = Artwork(id: 456, title: "Some art", artistTitle: "John Doe", departmentTitle: "Contemporary", imageId: nil)
     static let artworkList = ArtworkList(pagination: Pagination(total: 1, totalPages: 1), data: [artworkWithImage])
     
     static let artworkDetail: ArtworkDetail = ArtworkDetail(id: 123,

--- a/BitsoArtGalleryTests/ViewModels/ArtworkDetailViewModelTests.swift
+++ b/BitsoArtGalleryTests/ViewModels/ArtworkDetailViewModelTests.swift
@@ -15,7 +15,7 @@ final class ArtworkDetailViewModelTests: XCTestCase {
     func testLoadArtwork_whenServiceSucceeds_shouldRenderArtwork() async {
         
         let loader = MockArtworkLoader()
-        viewModel = ArtworkDetailViewModel(artworkLoader: loader, artworkId: 123)
+        viewModel = ArtworkDetailViewModel(artworkLoader: loader, artwork: MockArtworks.artworkWithImage)
         
         await viewModel.loadArtwork()
         
@@ -27,11 +27,11 @@ final class ArtworkDetailViewModelTests: XCTestCase {
     func testLoadArtwork_whenServiceFails_shouldRenderError() async {
         
         let loader = MockArtworkLoader()
-        viewModel = ArtworkDetailViewModel(artworkLoader: loader, artworkId: 1434343)
+        viewModel = ArtworkDetailViewModel(artworkLoader: loader, artwork: MockArtworks.artworkWithoutImage)
         
         await viewModel.loadArtwork()
         
-        XCTAssertNil(viewModel.artwork)
+        XCTAssertNil(viewModel.artworkDetail)
         XCTAssertTrue(viewModel.isShowingError)
     }
     
@@ -39,7 +39,7 @@ final class ArtworkDetailViewModelTests: XCTestCase {
     func testGetDescription_shouldRemoveHTMLFromDescription() {
         
         let loader = MockArtworkLoader()
-        viewModel = ArtworkDetailViewModel(artworkLoader: loader, artworkId: 1434343)
+        viewModel = ArtworkDetailViewModel(artworkLoader: loader, artwork: MockArtworks.artworkWithImage)
         
         let artworkDetail = ArtworkDetail(id: 123,
                                                          title: "Some art",
@@ -53,7 +53,7 @@ final class ArtworkDetailViewModelTests: XCTestCase {
                                                          creditLine: "Gift of John Doe",
                                                          galleryTitle: "Gallery 1",
                                                          departmentTitle: "Modern Art")
-        viewModel.artwork = artworkDetail
+        viewModel.artworkDetail = artworkDetail
         let result = viewModel.getDescription()
         
         XCTAssertNotNil(result)


### PR DESCRIPTION
Previously artwork detail was fetched in a second api call to /artwork/:id. This caused that the response would not be saved for offline use in files if the user didn't access the artwork's detail. Now, Im using the basic information fetched in the list to prepopulate the artwork detail view, in order to show *some* information when offline.